### PR TITLE
enable more accurate advanced emulation settings

### DIFF
--- a/GUI.NET/Config/EmulationInfo.cs
+++ b/GUI.NET/Config/EmulationInfo.cs
@@ -19,12 +19,12 @@ namespace Mesen.GUI.Config
 		public bool DisablePaletteRead = false;
 		public bool DisableOamAddrBug = false;
 		public bool DisablePpuReset = false;
-		public bool EnableOamDecay = false;
+		public bool EnableOamDecay = true;
 		public bool UseNes101Hvc101Behavior = false;
-		public bool EnableMapperRandomPowerOnState = false;
-		public bool RandomizeCpuPpuAlignment = false;
-		public bool EnablePpu2006ScrollGlitch = false;
-		public bool EnablePpu2000ScrollGlitch = false;
+		public bool EnableMapperRandomPowerOnState = true;
+		public bool RandomizeCpuPpuAlignment = true;
+		public bool EnablePpu2006ScrollGlitch = true;
+		public bool EnablePpu2000ScrollGlitch = true;
 
 		public bool UseAlternativeMmc3Irq = false;
 
@@ -33,7 +33,7 @@ namespace Mesen.GUI.Config
 
 		public RamPowerOnState RamPowerOnState;
 
-		public bool ShowLagCounter = false;
+		public bool ShowLagCounter = true;
 
 		[MinMax(0, 5000)] public UInt32 EmulationSpeed = 100;
 		[MinMax(0, 5000)] public UInt32 TurboSpeed = 300;
@@ -51,22 +51,22 @@ namespace Mesen.GUI.Config
 			InteropEmu.SetTurboRewindSpeed(emulationInfo.TurboSpeed, emulationInfo.RewindSpeed);
 
 			InteropEmu.SetFlag(EmulationFlags.Mmc3IrqAltBehavior, emulationInfo.UseAlternativeMmc3Irq);
-			InteropEmu.SetFlag(EmulationFlags.AllowInvalidInput, emulationInfo.AllowInvalidInput);
-			InteropEmu.SetFlag(EmulationFlags.ShowLagCounter, emulationInfo.ShowLagCounter);
+			InteropEmu.SetFlag(EmulationFlags.AllowInvalidInput, false);
+			InteropEmu.SetFlag(EmulationFlags.ShowLagCounter, true);
 			InteropEmu.SetFlag(EmulationFlags.DisablePpu2004Reads, emulationInfo.DisablePpu2004Reads);
 			InteropEmu.SetFlag(EmulationFlags.DisablePaletteRead, emulationInfo.DisablePaletteRead);
 			InteropEmu.SetFlag(EmulationFlags.DisableOamAddrBug, emulationInfo.DisableOamAddrBug);
 			InteropEmu.SetFlag(EmulationFlags.DisablePpuReset, emulationInfo.DisablePpuReset);
-			InteropEmu.SetFlag(EmulationFlags.EnableOamDecay, emulationInfo.EnableOamDecay);
+			InteropEmu.SetFlag(EmulationFlags.EnableOamDecay, true);
 			InteropEmu.SetFlag(EmulationFlags.UseNes101Hvc101Behavior, emulationInfo.UseNes101Hvc101Behavior);
-			InteropEmu.SetFlag(EmulationFlags.RandomizeMapperPowerOnState, emulationInfo.EnableMapperRandomPowerOnState);
-			InteropEmu.SetFlag(EmulationFlags.RandomizeCpuPpuAlignment, emulationInfo.RandomizeCpuPpuAlignment);
-			InteropEmu.SetFlag(EmulationFlags.EnablePpu2000ScrollGlitch, emulationInfo.EnablePpu2000ScrollGlitch);
-			InteropEmu.SetFlag(EmulationFlags.EnablePpu2006ScrollGlitch, emulationInfo.EnablePpu2006ScrollGlitch);
+			InteropEmu.SetFlag(EmulationFlags.RandomizeMapperPowerOnState, true);
+			InteropEmu.SetFlag(EmulationFlags.RandomizeCpuPpuAlignment, true);
+			InteropEmu.SetFlag(EmulationFlags.EnablePpu2000ScrollGlitch, true);
+			InteropEmu.SetFlag(EmulationFlags.EnablePpu2006ScrollGlitch, true);
 
 			InteropEmu.SetPpuNmiConfig(emulationInfo.PpuExtraScanlinesBeforeNmi, emulationInfo.PpuExtraScanlinesAfterNmi);
 
-			InteropEmu.SetRamPowerOnState(emulationInfo.RamPowerOnState);
+			InteropEmu.SetRamPowerOnState(Mesen.GUI.RamPowerOnState.Random);
 		}
 	}
 }

--- a/GUI.NET/Forms/Config/frmEmulationConfig.Designer.cs
+++ b/GUI.NET/Forms/Config/frmEmulationConfig.Designer.cs
@@ -402,7 +402,8 @@ namespace Mesen.GUI.Forms.Config
             // chkEnablePpu2000ScrollGlitch
             // 
             this.chkEnablePpu2000ScrollGlitch.AutoSize = true;
-            this.chkEnablePpu2000ScrollGlitch.Checked = false;
+            this.chkEnablePpu2000ScrollGlitch.Checked = true;
+            this.chkEnablePpu2000ScrollGlitch.Enabled = false;
             this.chkEnablePpu2000ScrollGlitch.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkEnablePpu2000ScrollGlitch.Location = new System.Drawing.Point(10, 112);
             this.chkEnablePpu2000ScrollGlitch.Margin = new System.Windows.Forms.Padding(10, 0, 0, 0);
@@ -415,7 +416,8 @@ namespace Mesen.GUI.Forms.Config
             // chkEnablePpu2006ScrollGlitch
             // 
             this.chkEnablePpu2006ScrollGlitch.AutoSize = true;
-            this.chkEnablePpu2006ScrollGlitch.Checked = false;
+            this.chkEnablePpu2006ScrollGlitch.Checked = true;
+            this.chkEnablePpu2006ScrollGlitch.Enabled = false;
             this.chkEnablePpu2006ScrollGlitch.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkEnablePpu2006ScrollGlitch.Location = new System.Drawing.Point(10, 89);
             this.chkEnablePpu2006ScrollGlitch.Margin = new System.Windows.Forms.Padding(10, 0, 0, 0);
@@ -428,7 +430,8 @@ namespace Mesen.GUI.Forms.Config
             // chkRandomizeCpuPpuAlignment
             // 
             this.chkRandomizeCpuPpuAlignment.AutoSize = true;
-            this.chkRandomizeCpuPpuAlignment.Checked = false;
+            this.chkRandomizeCpuPpuAlignment.Checked = true;
+            this.chkRandomizeCpuPpuAlignment.Enabled = false;
             this.chkRandomizeCpuPpuAlignment.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkRandomizeCpuPpuAlignment.Location = new System.Drawing.Point(10, 66);
             this.chkRandomizeCpuPpuAlignment.Margin = new System.Windows.Forms.Padding(10, 0, 0, 0);
@@ -453,7 +456,8 @@ namespace Mesen.GUI.Forms.Config
             // chkMapperRandomPowerOnState
             // 
             this.chkMapperRandomPowerOnState.AutoSize = true;
-            this.chkMapperRandomPowerOnState.Checked = false;
+            this.chkMapperRandomPowerOnState.Checked = true;
+            this.chkMapperRandomPowerOnState.Enabled = false;
             this.chkMapperRandomPowerOnState.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkMapperRandomPowerOnState.Location = new System.Drawing.Point(10, 43);
             this.chkMapperRandomPowerOnState.Margin = new System.Windows.Forms.Padding(10, 0, 0, 0);
@@ -465,7 +469,8 @@ namespace Mesen.GUI.Forms.Config
             // 
             // chkEnableOamDecay
             // 
-            this.chkEnableOamDecay.Checked = false;
+            this.chkEnableOamDecay.Checked = true;
+            this.chkEnableOamDecay.Enabled = false;
             this.chkEnableOamDecay.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkEnableOamDecay.Location = new System.Drawing.Point(10, 20);
             this.chkEnableOamDecay.Margin = new System.Windows.Forms.Padding(10, 0, 0, 0);
@@ -558,6 +563,7 @@ namespace Mesen.GUI.Forms.Config
             // 
             this.chkAllowInvalidInput.AutoSize = true;
             this.chkAllowInvalidInput.Checked = false;
+            this.chkAllowInvalidInput.Enabled = false;
             this.chkAllowInvalidInput.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkAllowInvalidInput.Location = new System.Drawing.Point(10, 319);
             this.chkAllowInvalidInput.Margin = new System.Windows.Forms.Padding(10, 0, 0, 0);


### PR DESCRIPTION
Permanently enable the advanced emulation settings which improve
accuracy. Display those form elements as disabled fields.

> [✓] Enable OAM RAM Decay
> [✓] Randomize power-on state for mappers
> [✓] Randomize power-on/ reset CPU/PPU alignment
> [✓] Enable PPU $2006 scroll glitch emulation
> [✓] Enable PPU $2000/ $2005/ $2006 first-write scroll glitch emulation
>
> Default power on state for RAM: [Random Values]

Also disable "Allow Invalid Input".